### PR TITLE
Minor workflow changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 __pycache__
 *.pyc
-build*
+/build*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,33 @@
 # Changelog
 
-## Current main
+## 0.3.0
+
+### Spack Integration
 - Add workaround for Spack changing how configuration scopes are overriden.
   See https://github.com/spack/spack/issues/52016. This adds a requirement to
   Spack develop-2026-03-01 or newer.
+- Fix spack includes operating differently (#2)
+- Fix handling of empty root specs in spack (#11)
+- Preserve misc and python cache during spack finalize (#10)
+
+### Build Environment
+- Add `kessel build-env --inplace` option (#18)
+- Add option to disable tests in build_environment workflow (#12)
+- Only update user build cache index when explicitly requested
+- Fix how KESSEL_ENABLE_VIEW is set (#6)
+
+### Mirrors and Deployments
+- Add metadata for local mirror support (#16)
+- Default to mirroring private packages in deployments
+- Fix spack deployments finalize when using padding (#5)
+- Propagate environment step errors in spack deployments
+
+### Workflows
+- Improve error handling and early exits in workflows (#8)
+- Consolidate base workflow files (#1)
+
+### CI/CD
+- Enable CI PR checks (#3)
 
 ## 0.2.0
 - first public release

--- a/doc/sphinx/deployments.rst
+++ b/doc/sphinx/deployments.rst
@@ -73,7 +73,7 @@ Edit ``.kessel/workflows/default.py`` to configure your deployment:
 
        # Spack version to use
        spack_url = "https://github.com/spack/spack.git"
-       spack_ref = "v1.1.0"
+       spack_ref = "v1.2.0"
 
        # Deployment options
        build_roots = False
@@ -101,7 +101,7 @@ Configuration Options
   Git URL for the Spack repository. Default: ``https://github.com/spack/spack.git``
 
 **spack_ref**
-  Git branch, tag, or commit to use. Examples: ``v1.1.0``, ``develop``
+  Git branch, tag, or commit to use. Examples: ``v1.2.0``, ``develop``
 
 **site_configs_url**
   Git URL for a site-specific configuration repository (optional). When provided, this repository is cloned into ``config/site/`` during deployment setup and included in the Spack configuration hierarchy. Default: ``""`` (disabled)
@@ -274,7 +274,7 @@ Enable site configs in your deployment workflow:
 
    class Default(Deployment):
        spack_url = "https://github.com/spack/spack.git"
-       spack_ref = "v1.1.0"
+       spack_ref = "v1.2.0"
 
        # Site-specific configuration
        site_configs_url = "https://github.com/myorg/spack-site-configs.git"
@@ -397,7 +397,7 @@ Suppose you manage deployments for multiple HPC facilities:
 
    class Default(Deployment):
        spack_url = "https://github.com/spack/spack.git"
-       spack_ref = "v1.1.0"
+       spack_ref = "v1.2.0"
 
        # Shared configuration for all facilities
        site_configs_url = "https://github.com/hpc-facilities/spack-configs.git"
@@ -695,7 +695,7 @@ The ``git_mirrors`` list specifies paths (relative to the deployment project) th
 Deployment Best Practices
 --------------------------
 
-1. **Pin Spack versions**: Use specific tags (e.g., ``v1.1.0``) rather than ``develop`` for reproducibility
+1. **Pin Spack versions**: Use specific tags (e.g., ``v1.2.0``) rather than ``develop`` for reproducibility
 2. **Test locally first**: Create deployments on a local system before deploying to production
 3. **Use external packages**: Mark system packages as external to avoid rebuilding them
 4. **Exclude build dependencies**: Use ``build_exclude`` to remove packages only needed during builds
@@ -756,7 +756,7 @@ Here's a complete example for a deployment with LAMMPS:
        steps = ["setup", "bootstrap", "mirror", "envs", "finalize"]
 
        spack_url = "https://github.com/spack/spack.git"
-       spack_ref = "v1.1.0"
+       spack_ref = "v1.2.0"
 
        build_roots = True
        env_views = True

--- a/doc/sphinx/tutorial/deployment.rst
+++ b/doc/sphinx/tutorial/deployment.rst
@@ -111,7 +111,7 @@ Edit ``.kessel/workflows/default.py``:
 
        # Spack version to use
        spack_url = "https://github.com/spack/spack.git"
-       spack_ref = "v1.1.0"
+       spack_ref = "v1.2.0"
 
        # Site-specific configuration (optional)
        site_configs_url = ""    # Git URL for site configs (e.g., "https://github.com/myorg/site-configs.git")
@@ -280,7 +280,7 @@ Edit ``.kessel/workflows/default.py`` to add logic for cloning your source repos
 
        # Spack version to use
        spack_url = "https://github.com/spack/spack.git"
-       spack_ref = "v1.1.0"
+       spack_ref = "v1.2.0"
 
        # Deployment options
        build_roots = True       # Build the root specs (not just dependencies)

--- a/doc/sphinx/workflows.rst
+++ b/doc/sphinx/workflows.rst
@@ -290,7 +290,7 @@ The ``Deployment`` workflow class creates Spack deployments:
        
        # Spack configuration
        spack_url = "https://github.com/spack/spack.git"
-       spack_ref = "v1.1.0"
+       spack_ref = "v1.2.0"
        
        # Deployment options
        build_roots = False

--- a/lib/kessel/__init__.py
+++ b/lib/kessel/__init__.py
@@ -9,4 +9,4 @@
 # in this material to reproduce, prepare derivative works, distribute copies to
 # the public, perform publicly and display publicly, and to permit others to do
 # so.
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/lib/kessel/workflows/base/spack/build_environment/prepare_env.sh
+++ b/lib/kessel/workflows/base/spack/build_environment/prepare_env.sh
@@ -54,6 +54,8 @@ fi
 
 if spack find -r 2>/dev/null | grep -q "[Nn]o root specs"; then
   spack add "$KESSEL_PROJECT_SPEC"
+else
+  spack change "$KESSEL_PROJECT_SPEC"
 fi
 
 # now that Spack "should" know about it, we'll ask again (TODO: is this still necessary?)

--- a/lib/kessel/workflows/base/spack/build_environment/prepare_env.sh
+++ b/lib/kessel/workflows/base/spack/build_environment/prepare_env.sh
@@ -68,5 +68,7 @@ spack config add "packages:${KESSEL_PROJECT_NAME}:package_attributes:keep_werror
 if [ -n "${KESSEL_USER_BUILD_CACHE}" ]; then
   mkdir -p "${KESSEL_USER_BUILD_CACHE}"
   spack mirror add --type binary --autopush --unsigned user-ci-mirror "${KESSEL_USER_BUILD_CACHE}"
-  spack buildcache update-index "${KESSEL_USER_BUILD_CACHE}" || true
+  if [ "${KESSEL_USER_BUILD_CACHE_UPDATE_INDEX}" ]; then
+    spack buildcache update-index "${KESSEL_USER_BUILD_CACHE}" || true
+  fi
 fi

--- a/lib/kessel/workflows/base/spack/deployment/mirror.sh
+++ b/lib/kessel/workflows/base/spack/deployment/mirror.sh
@@ -44,9 +44,9 @@ create_env_mirror() {
         spack spec
         if [ -f "$SPACK_ENV/spack.lock" ]; then
             if [ -f "$mirror_exclude_file" ]; then
-                spack mirror create -d "$mirror_dir" --all --skip-unstable-version --exclude-file "$mirror_exclude_file"
+                spack mirror create -d "$mirror_dir" --all --private --skip-unstable-version --exclude-file "$mirror_exclude_file"
             else
-                spack mirror create -d "$mirror_dir" --all --skip-unstable-version
+                spack mirror create -d "$mirror_dir" --all --private --skip-unstable-version
             fi
         else
             echo "SKIPPING $env_name due to missing concrete specs."


### PR DESCRIPTION
- add `spack change` for updating build environment
- deployments now default to also mirror private packages
- user build cache index updates are now optional, since not technically needed for install
- mark 0.3.0 release and update CHANGELOG.