### PR TITLE
print meaningful error for kessel step without arg

### DIFF
--- a/lib/kessel/cmd/step.py
+++ b/lib/kessel/cmd/step.py
@@ -39,7 +39,7 @@ def step(args: Namespace, ctx: Context, senv: ShellEnvironment) -> None:
 
 
 def setup_command(subparser: ArgumentParser, ctx: Context) -> None:
-    subparsers = subparser.add_subparsers()
+    subparsers = subparser.add_subparsers(required=True)
 
     if ctx.kessel_dir and ctx.workflow_config:
         workflow = ctx.workflow_config

--- a/lib/kessel/main.py
+++ b/lib/kessel/main.py
@@ -84,6 +84,7 @@ def main() -> int:
     senv.debug = args.shell_debug
     senv.eval("set --")  # makes sure sourced scripts don't see our args
     interactive = sys.stdout.isatty() and not args.shell_debug and args.command in ("run", "step")
+    stop_event = None
     try:
         if hasattr(args, "func"):
             if interactive:
@@ -99,7 +100,7 @@ def main() -> int:
         print("ERROR:", e)
         return 1
     finally:
-        if interactive:
+        if interactive and stop_event:
             stop_event.set()
             t.join()
     return 0


### PR DESCRIPTION
Without the just doing `kessel step` would throw an exception. Instead it should tell you what steps are available.